### PR TITLE
Fix Read the Docs rendering

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 master
 ------
 
+- (`#20 <https://github.com/openscm/openscm-units/pull/20>`_) Make ``openscm_units.data`` a module by adding an ``__init__.py`` file to it and add docs for ``openscm_units.data`` (closes `#19 <https://github.com/openscm/openscm-units/issues/19>`_)
 - (`#18 <https://github.com/openscm/openscm-units/pull/18>`_) Made NH3 a separate dimension to avoid accidental conversion to CO2 in GWP contexts. Also added an ``nh3_conversions`` context to convert to nitrogen (closes `#12 <https://github.com/openscm/openscm-units/issues/12>`_)
 - (`#16 <https://github.com/openscm/openscm-units/pull/16>`_) Added refrigerant mixtures as units, including automatic GWP calculation from the GWP of their constituents. Also added the ``unit_registry.split_gas_mixtures`` function which can be used to split quantities containing a gas mixture into their constituents (closes `#10 <https://github.com/openscm/openscm-units/issues/10>`_)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,6 +43,15 @@ extensions = [
     "sphinx.ext.napoleon",  # pass numpy style docstrings
 ]
 
+autodoc_default_options = {
+    "members": True,
+    "undoc-members": False,
+    "private-members": False,
+    "special-members": False,
+    "inherited-members": True,
+    "show-inheritance": True,
+}
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 

--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -1,0 +1,11 @@
+.. _data-reference:
+
+Data API
+--------
+
+.. automodule:: openscm_units.data
+
+Mixtures API
+============
+
+.. automodule:: openscm_units.data.mixtures

--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -8,4 +8,5 @@ Data API
 Mixtures API
 ============
 
-.. automodule:: openscm_units.data.mixtures
+.. autodata:: openscm_units.data.mixtures.MIXTURES
+   :annotation:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,6 +27,7 @@ OpenSCM-Units
     :caption: API reference
 
     unit_registry
+    data
 
 .. toctree::
     :maxdepth: 2

--- a/src/openscm_units/data/__init__.py
+++ b/src/openscm_units/data/__init__.py
@@ -1,0 +1,6 @@
+"""
+Data used within OpenSCM Units
+
+For example, metric conversions and breakdownss of mixture substances into
+their constituents.
+"""

--- a/src/openscm_units/data/mixtures.py
+++ b/src/openscm_units/data/mixtures.py
@@ -402,6 +402,8 @@ MIXTURES = {
 """
 dict: Gas mixtures supported by OpenSCM Units
 
+Last update: 2020-12-16
+
 Each key is the mixture's name. Each value is itself a dictionary where each
 key is the name of a component of the mixture and the value is a list in which
 the first element is the standard composition, the second element is the positive
@@ -412,5 +414,5 @@ Sources:
 
 - ANSI/ASHRAE Standard 34-2019, p. 9ff, ISSN 1041-2336, https://www.techstreet.com/ashrae/standards/ashrae-15-2019-packaged-w-34-2019?product_id=2046531
 
-- https://en.wikipedia.org/wiki/List_of_refrigerants (for common names), last update: 2020-12-16
+- https://en.wikipedia.org/wiki/List_of_refrigerants (for common names)
 """

--- a/src/openscm_units/data/mixtures.py
+++ b/src/openscm_units/data/mixtures.py
@@ -1,21 +1,13 @@
 """
-Gas mixtures
-Sources:
-- ANSI/ASHRAE Standard 34-2019, p. 9ff, ISSN 1041-2336,
-  https://www.techstreet.com/ashrae/standards/ashrae-15-2019-packaged-w-34-2019?product_id=2046531
-- https://en.wikipedia.org/wiki/List_of_refrigerants (for common names)
-Last update: 2020-12-16
-Everything is given in mass-%
-Given is the standard composition, and the positive and negative composition
-tolerances
+Gas mixtures supported by OpenSCM Units
 """
 
-nan = float("nan")
+_nan = float("nan")
 
 MIXTURES = {
     # note that CFC400 can also be a 60 / 40 split and the standard says it MUST be
     # specified, but it is almost never specified and 50/50 seems to be more common
-    "CFC400": {"CFC12": [50, nan, nan], "CFC114": [50, nan, nan]},
+    "CFC400": {"CFC12": [50, _nan, _nan], "CFC114": [50, _nan, _nan]},
     "HCFC401a": {
         "HCFC22": [53, 2, -2],
         "HFC152a": [13, 0.5, -1.5],
@@ -383,17 +375,17 @@ MIXTURES = {
         "C3H8": [7.9, 0.1, -0.9],
         "HFO1234yf": [71.1, 1, -1],
     },
-    "HCFC500": {"CFC12": [73.8, nan, nan], "HFC152": [26.2, nan, nan]},
-    "HCFC501": {"HCFC22": [75, nan, nan], "CFC12": [25, nan, nan]},
-    "HCFC502": {"HCFC22": [48.8, nan, nan], "CFC115": [51.2, nan, nan]},
-    "HCFC503": {"HFC23": [40.1, nan, nan], "CFC13": [59.9, nan, nan]},
-    "HCFC504": {"HFC32": [48.2, nan, nan], "CFC115": [51.8, nan, nan]},
-    "HCFC505": {"CFC12": [78, nan, nan], "HCFC31": [22, nan, nan]},
-    "HCFC506": {"HCFC31": [55.1, nan, nan], "CFC114": [44.9, nan, nan]},
-    "HFC507a": {"HFC125": [50, nan, nan], "HFC143a": [50, nan, nan]},
-    "HFC508a": {"HFC23": [39, nan, nan], "C2F6": [61, nan, nan]},
-    "HFC508b": {"HFC23": [46, nan, nan], "C2F6": [54, nan, nan]},
-    "HCFC509a": {"HCFC22": [44, nan, nan], "C3F8": [56, nan, nan]},
+    "HCFC500": {"CFC12": [73.8, _nan, _nan], "HFC152": [26.2, _nan, _nan]},
+    "HCFC501": {"HCFC22": [75, _nan, _nan], "CFC12": [25, _nan, _nan]},
+    "HCFC502": {"HCFC22": [48.8, _nan, _nan], "CFC115": [51.2, _nan, _nan]},
+    "HCFC503": {"HFC23": [40.1, _nan, _nan], "CFC13": [59.9, _nan, _nan]},
+    "HCFC504": {"HFC32": [48.2, _nan, _nan], "CFC115": [51.8, _nan, _nan]},
+    "HCFC505": {"CFC12": [78, _nan, _nan], "HCFC31": [22, _nan, _nan]},
+    "HCFC506": {"HCFC31": [55.1, _nan, _nan], "CFC114": [44.9, _nan, _nan]},
+    "HFC507a": {"HFC125": [50, _nan, _nan], "HFC143a": [50, _nan, _nan]},
+    "HFC508a": {"HFC23": [39, _nan, _nan], "C2F6": [61, _nan, _nan]},
+    "HFC508b": {"HFC23": [46, _nan, _nan], "C2F6": [54, _nan, _nan]},
+    "HCFC509a": {"HCFC22": [44, _nan, _nan], "C3F8": [56, _nan, _nan]},
     "HC510a": {"HCE170": [88, 0.5, -0.5], "HC600a": [12, 0.5, -0.5]},
     "HC511a": {"C3H8": [95, 1, -1], "HCE170": [5, 1, -1]},
     "HFC512a": {"HFC134a": [5, 1, -1], "HFC152a": [95, 1, -1]},
@@ -407,3 +399,18 @@ MIXTURES = {
         "HFC152a": [14, 0.1, -1.9],
     },
 }
+"""
+dict: Gas mixtures supported by OpenSCM Units
+
+Each key is the mixture's name. Each value is itself a dictionary where each
+key is the name of a component of the mixture and the value is a list in which
+the first element is the standard composition, the second element is the positive
+composition tolerance and the third element is the negative composition tolerance.
+All values are given in mass percentage.
+
+Sources:
+
+- ANSI/ASHRAE Standard 34-2019, p. 9ff, ISSN 1041-2336, https://www.techstreet.com/ashrae/standards/ashrae-15-2019-packaged-w-34-2019?product_id=2046531
+
+- https://en.wikipedia.org/wiki/List_of_refrigerants (for common names), last update: 2020-12-16
+"""


### PR DESCRIPTION
# Pull request

Closes #19 

New read the docs state can be viewed at https://openscm-units.readthedocs.io/en/19-fix-rtd/index.html

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Example added (either to an existing notebook or as a new notebook, where applicable) (N/A)
- [x] Description in ``CHANGELOG.rst`` added

## Adding to CHANGELOG.rst

Please add a single line in the changelog notes similar to one of the following:

```
- (`#XX <https://github.com/openscm/openscm-units/pull/XX>`_) Added feature which does something
- (`#XX <https://github.com/openscm/openscm-units/pull/XX>`_) Fixed bug identified in (`#YY <https://github.com/openscm/openscm-units/issues/YY>`_)
```
