### PR TITLE
Tweak metric conversions handling and add example notebook

### DIFF
--- a/notebooks/custom-conversions.ipynb
+++ b/notebooks/custom-conversions.ipynb
@@ -1,0 +1,188 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "446173ed",
+   "metadata": {},
+   "source": [
+    "# Custom conversions\n",
+    "\n",
+    "Here we show how custom conversions can be passed to OpenSCM-Units' `ScmUnitRegistry`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cd0c599a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "import traceback\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "from openscm_units import ScmUnitRegistry"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "711f59c0",
+   "metadata": {},
+   "source": [
+    "## Custom conversions DataFrame\n",
+    "\n",
+    "On initialisation, a `pd.DataFrame` can be provided which contains the custom conversions. This `pd.DataFrame` should be formatted as shown below, with an index that contains the different species and columns which contain the conversion for different metrics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a6ed71c3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Custom1</th>\n",
+       "      <th>Custom2</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Species</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>CH4</th>\n",
+       "      <td>20</td>\n",
+       "      <td>25</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>N2O</th>\n",
+       "      <td>341</td>\n",
+       "      <td>300</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         Custom1  Custom2\n",
+       "Species                  \n",
+       "CH4           20       25\n",
+       "N2O          341      300"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "metric_conversions_custom = pd.DataFrame([\n",
+    "    {\n",
+    "        \"Species\": \"CH4\",\n",
+    "        \"Custom1\": 20,\n",
+    "        \"Custom2\": 25,\n",
+    "    },\n",
+    "    {\n",
+    "        \"Species\": \"N2O\",\n",
+    "        \"Custom1\": 341,\n",
+    "        \"Custom2\": 300,\n",
+    "    },\n",
+    "]).set_index(\"Species\")\n",
+    "metric_conversions_custom"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b26b3ec2",
+   "metadata": {},
+   "source": [
+    "With such a `pd.DataFrame`, we can use custom conversions in our unit registry as shown."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "9f298b21",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'N2O: 1 N2O'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'N2O in CO2-equivalent: 341.0 CO2'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# initialise the unit registry with custom conversions\n",
+    "unit_registry = ScmUnitRegistry(metric_conversions=metric_conversions_custom)\n",
+    "# add standard conversions before moving on\n",
+    "unit_registry.add_standards()\n",
+    "\n",
+    "# start with e.g. N2O\n",
+    "nitrous_oxide = unit_registry(\"N2O\")\n",
+    "display(f\"N2O: {nitrous_oxide}\")\n",
+    "\n",
+    "# our unit registry allows us to make conversions using the \n",
+    "# conversion factors we previously defined\n",
+    "with unit_registry.context(\"Custom1\"):\n",
+    "    display(f\"N2O in CO2-equivalent: {nitrous_oxide.to('CO2')}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/openscm_units/_unit_registry.py
+++ b/src/openscm_units/_unit_registry.py
@@ -145,7 +145,6 @@ context analogous to the 'NOx_conversions' context:
 import math
 
 import globalwarmingpotentials
-import pandas as pd
 import pint
 
 from .data.mixtures import MIXTURES

--- a/src/openscm_units/_unit_registry.py
+++ b/src/openscm_units/_unit_registry.py
@@ -319,8 +319,12 @@ class ScmUnitRegistry(pint.UnitRegistry):
         Parameters
         ----------
         metric_conversions : [:obj:`pd.DataFrame`, None]
-            :obj:`pd.DataFrame` containing the metric conversions. If not
-            supplied, the ``globalwarmingpotentials`` package is used.
+            :obj:`pd.DataFrame` containing the metric conversions.
+            ``metric_conversions`` must have an index named ``"Species"`` that
+            contains the different species and columns which contain the
+            conversion for different metrics (the name of the metrics is taken
+            from the column names).If not supplied, the
+            ``globalwarmingpotentials`` package is used.
 
         *args
             Passed to the ``__init__`` method of the super class
@@ -464,8 +468,7 @@ class ScmUnitRegistry(pint.UnitRegistry):
         self._add_metric_conversions_from_df(metric_conversions)
 
     def _add_metric_conversions_from_df(self, metric_conversions):
-        # could make this public in future so people can write conversions
-        # in memory and then set them
+        # could make this public in future
         for col in metric_conversions:
             metric_conversion = metric_conversions[col]
             transform_context = pint.Context(col)

--- a/src/openscm_units/_unit_registry.py
+++ b/src/openscm_units/_unit_registry.py
@@ -312,15 +312,15 @@ class ScmUnitRegistry(pint.UnitRegistry):
 
     _contexts_loaded = False
 
-    def __init__(self, *args, metric_conversions_csv=None, **kwargs):
+    def __init__(self, *args, metric_conversions=None, **kwargs):
         """
         Initialise the unit registry
 
         Parameters
         ----------
-        metric_conversions_csv : str
-            csv file containing the metric conversions. If not supplied,
-            the internal metric conversions csv is used.
+        metric_conversions : [:obj:`pd.DataFrame`, None]
+            :obj:`pd.DataFrame` containing the metric conversions. If not
+            supplied, the ``globalwarmingpotentials`` package is used.
 
         *args
             Passed to the ``__init__`` method of the super class
@@ -328,7 +328,7 @@ class ScmUnitRegistry(pint.UnitRegistry):
         **kwargs
             Passed to the ``__init__`` method of the super class
         """
-        self._metric_conversions_csv = metric_conversions_csv
+        self._metric_conversions = metric_conversions
         super().__init__(*args, **kwargs)
 
     def add_standards(self):
@@ -456,19 +456,10 @@ class ScmUnitRegistry(pint.UnitRegistry):
 
         This is done only when contexts are needed to avoid reading files on import.
         """
-        if self._metric_conversions_csv is None:
+        if self._metric_conversions is None:
             metric_conversions = globalwarmingpotentials.as_frame()
         else:
-            to_read = self._metric_conversions_csv
-
-            metric_conversions = pd.read_csv(
-                to_read,
-                skiprows=1,  # skip source row
-                header=0,
-                index_col=0,
-            ).iloc[
-                1:, :
-            ]  # drop out 'SCMData base unit' row
+            metric_conversions = self._metric_conversions
 
         self._add_metric_conversions_from_df(metric_conversions)
 

--- a/src/openscm_units/_unit_registry.py
+++ b/src/openscm_units/_unit_registry.py
@@ -305,11 +305,10 @@ class ScmUnitRegistry(pint.UnitRegistry):
     """
     Unit registry class.
 
-    Provides some convenience methods to add standard units and contexts with
-    lazy loading from disk.
+    Provides some convenience methods to add standard units and contexts.
     """
 
-    _contexts_loaded = False
+    _contexts_added = False
 
     def __init__(self, *args, metric_conversions=None, **kwargs):
         """
@@ -360,12 +359,12 @@ class ScmUnitRegistry(pint.UnitRegistry):
 
     def enable_contexts(self, *names_or_contexts, **kwargs):
         """
-        Overload pint's :func:`enable_contexts` to load contexts once (the first time
-        they are used) to avoid (unnecessary) file operations on import.
+        Overload pint's :func:`enable_contexts` to add contexts once (the first time
+        they are used) to avoid (unnecessary) operations.
         """
-        if not self._contexts_loaded:
-            self._load_contexts()
-        self._contexts_loaded = True
+        if not self._contexts_added:
+            self._add_contexts()
+        self._contexts_added = True
         super().enable_contexts(*names_or_contexts, **kwargs)
 
     def _add_mass_emissions_joint_version(self, symbol):
@@ -403,9 +402,9 @@ class ScmUnitRegistry(pint.UnitRegistry):
                 self.define("{} = {}".format(symbol.upper(), symbol))
                 self._add_mass_emissions_joint_version(symbol.upper())
 
-    def _load_contexts(self):
+    def _add_contexts(self):
         """
-        Load contexts.
+        Add contexts
         """
         _ch4_context = pint.Context("CH4_conversions")
         _ch4_context = self._add_transformations_to_context(
@@ -451,13 +450,11 @@ class ScmUnitRegistry(pint.UnitRegistry):
         )
         self.add_context(_nh3_context)
 
-        self._load_metric_conversions()
+        self._add_metric_conversions()
 
-    def _load_metric_conversions(self):
+    def _add_metric_conversions(self):
         """
-        Load metric conversion contexts from file.
-
-        This is done only when contexts are needed to avoid reading files on import.
+        Add metric conversion contexts
         """
         if self._metric_conversions is None:
             metric_conversions = globalwarmingpotentials.as_frame()

--- a/tests/integration/test_custom_context_csv.py
+++ b/tests/integration/test_custom_context_csv.py
@@ -31,18 +31,20 @@ def test_custom_context_csv(test_data_dir):
 
 
 def test_custom_context():
-    metric_conversions_custom = pd.DataFrame([
-        {
-            "Species": "CH4",
-            "Custom1": 20,
-            "Custom2": 25,
-        },
-        {
-            "Species": "N2O",
-            "Custom1": 341,
-            "Custom2": 300,
-        },
-    ]).set_index("Species")
+    metric_conversions_custom = pd.DataFrame(
+        [
+            {
+                "Species": "CH4",
+                "Custom1": 20,
+                "Custom2": 25,
+            },
+            {
+                "Species": "N2O",
+                "Custom1": 341,
+                "Custom2": 300,
+            },
+        ]
+    ).set_index("Species")
 
     unit_registry = ScmUnitRegistry(metric_conversions=metric_conversions_custom)
     unit_registry.add_standards()

--- a/tests/integration/test_custom_context_csv.py
+++ b/tests/integration/test_custom_context_csv.py
@@ -1,14 +1,21 @@
 import os.path
 
 import numpy as np
+import pandas as pd
 
 from openscm_units import ScmUnitRegistry
 
 
 def test_custom_context_csv(test_data_dir):
     custom_context_csv = os.path.join(test_data_dir, "custom-context.csv")
+    metric_conversions = pd.read_csv(
+        custom_context_csv,
+        skiprows=1,  # skip source row
+        header=0,
+        index_col=0,
+    )
 
-    unit_registry = ScmUnitRegistry(metric_conversions_csv=custom_context_csv)
+    unit_registry = ScmUnitRegistry(metric_conversions=metric_conversions)
     unit_registry.add_standards()
 
     nitrous_oxide = unit_registry("N2O")
@@ -21,3 +28,32 @@ def test_custom_context_csv(test_data_dir):
     with unit_registry.context("SARGWP100"):
         np.testing.assert_allclose(nitrous_oxide.to("CO2").magnitude, 310)
         np.testing.assert_allclose(methane.to("CO2").magnitude, 21)
+
+
+def test_custom_context():
+    metric_conversions_custom = pd.DataFrame([
+        {
+            "Species": "CH4",
+            "Custom1": 20,
+            "Custom2": 25,
+        },
+        {
+            "Species": "N2O",
+            "Custom1": 341,
+            "Custom2": 300,
+        },
+    ]).set_index("Species")
+
+    unit_registry = ScmUnitRegistry(metric_conversions=metric_conversions_custom)
+    unit_registry.add_standards()
+
+    nitrous_oxide = unit_registry("N2O")
+    methane = unit_registry("CH4")
+
+    with unit_registry.context("Custom1"):
+        np.testing.assert_allclose(nitrous_oxide.to("CO2").magnitude, 341)
+        np.testing.assert_allclose(methane.to("CO2").magnitude, 20)
+
+    with unit_registry.context("Custom2"):
+        np.testing.assert_allclose(nitrous_oxide.to("CO2").magnitude, 300)
+        np.testing.assert_allclose(methane.to("CO2").magnitude, 25)

--- a/tests/test-data/custom-context.csv
+++ b/tests/test-data/custom-context.csv
@@ -1,6 +1,5 @@
 Source,https://www.ghgprotocol.org/sites/default/files/ghgp/Global-Warming-Potential-Values%20%28Feb%2016%202016%29_1.pdf,
-OpenSCMMetricName,SARGWP100,TestCustomContext
-OpenSCM species,,
+Species,SARGWP100,TestCustomContext
 CH4,21,22
 N2O,310,345
 CFC11,3800,


### PR DESCRIPTION
If we're going to use the gwp package, I figure we may as well get rid of all the reading off disk stuff. Makes more sense for users to be able to generate their conversions in memory if they wish rather than forcing things to be read off disk. 