### PR TITLE
Updated outdated docs about NOx conversions.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ master
 ------
 
 - (`#33 <https://github.com/openscm/openscm-units/pull/33>`_) Generate static usage documentation from the introduction notebook
+- (`#34 <https://github.com/openscm/openscm-units/pull/34>`_) Update documentation regarding NOx conversions.
 
 v0.5.0
 ------

--- a/src/openscm_units/_unit_registry.py
+++ b/src/openscm_units/_unit_registry.py
@@ -34,8 +34,8 @@ For emissions units, there are a few cases to be considered:
 
 - fairly obvious ones e.g. carbon dioxide emissions can be provided in 'C' or 'CO2' and
   converting between the two is possible
-- less obvious ones e.g. NOx emissions can be provided in 'N' or 'NOx' (a short-hand
-  which is assumed to be NO2), we provide conversions between these two
+- less obvious ones e.g. NOx emissions can be provided in 'N' or 'NOx', we provide
+  conversions between these two which can be enabled if needed (see below).
 - case-sensitivity. In order to provide a simplified interface, using all uppercase
   versions of any unit is also valid e.g. ``unit_registry("HFC4310mee")`` is the same as
   ``unit_registry("HFC4310MEE")``


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [ ] Tests added
- [x] Documentation added (where applicable)
- [ ] Example added (either to an existing notebook or as a new notebook, where applicable)
- [x] Description in ``CHANGELOG.rst`` added

NOx is not a simple alias for NO2 any more. Update docs accordingly.

Prompted by https://github.com/pik-primap/primap2/discussions/96
