### PR TITLE
fix: iteritems() doesn't exist in pandas anymore.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ master
 
 - (`#33 <https://github.com/openscm/openscm-units/pull/33>`_) Generate static usage documentation from the introduction notebook
 - (`#34 <https://github.com/openscm/openscm-units/pull/34>`_) Update documentation regarding NOx conversions.
+- (`#38 <https://github.com/openscm/openscm-units/pull/38>`_) Fixed Series.iteritems() removal in pandas, see e.g. `#150 in primap2 <https://github.com/pik-primap/primap2/issues/150>`_
+
 
 v0.5.0
 ------

--- a/src/openscm_units/_unit_registry.py
+++ b/src/openscm_units/_unit_registry.py
@@ -145,6 +145,7 @@ context analogous to the 'NOx_conversions' context:
 import math
 
 import globalwarmingpotentials
+import pandas as pd
 import pint
 
 from .data.mixtures import MIXTURES
@@ -463,12 +464,12 @@ class ScmUnitRegistry(pint.UnitRegistry):
 
         self._add_metric_conversions_from_df(metric_conversions)
 
-    def _add_metric_conversions_from_df(self, metric_conversions):
+    def _add_metric_conversions_from_df(self, metric_conversions: pd.DataFrame):
         # could make this public in future
         for col in metric_conversions:
-            metric_conversion = metric_conversions[col]
+            metric_conversion: pd.Series = metric_conversions[col]
             transform_context = pint.Context(col)
-            for label, val in metric_conversion.iteritems():
+            for label, val in metric_conversion.items():
                 transform_context = self._add_gwp_to_context(
                     transform_context, label, val
                 )


### PR DESCRIPTION
# Pull request

With the latest pandas, 80% of the test suite fails because `Series.iteritems()` doesn't exist anymore. Spelling it `Series.items()` instead works. Also fixes https://github.com/pik-primap/primap2/issues/150 .

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Example added (either to an existing notebook or as a new notebook, where applicable)
- [x] Description in `CHANGELOG.rst` added

