### PR TITLE
Alias fix up

### DIFF
--- a/changelog/53.fix.md
+++ b/changelog/53.fix.md
@@ -1,0 +1,20 @@
+Fixed accidental aliasing of "yr" to "a".
+
+We had accidentally assigned "yr" to be an alias for "a".
+This meant we had the following behaviour
+
+```python
+>>> from openscm_units import unit_registry
+>>> val = unit_registry.Quantity(1, "yr")
+>>> val
+<Quantity(1, 'a')>
+```
+
+This PR fixes this so that if you pass in "yr", it stays as yr i.e. you get
+
+```python
+>>> from openscm_units import unit_registry
+>>> val = unit_registry.Quantity(1, "yr")
+>>> val
+<Quantity(1, 'yr')>
+```

--- a/src/openscm_units/_unit_registry.py
+++ b/src/openscm_units/_unit_registry.py
@@ -232,7 +232,8 @@ class ScmUnitRegistry(pint.UnitRegistry):
 
         self._add_gases({x: x for x in MIXTURES})
 
-        self.define("a = 1 * year = annum = yr")
+        self.define("yr = 1 * year")
+        self.define("a = 1 * year = annum")
         self.define("h = hour")
         self.define("d = day")
         self.define("degreeC = degC")

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -396,7 +396,13 @@ def test_no_autoconversion(inp):
     assert str(res.units) == inp
 
 
-@pytest.mark.parametrize("alias, exp", (("degC", "degree_Celsius"),))
+@pytest.mark.parametrize(
+    "alias, exp",
+    (
+        ("annum", "a"),
+        ("degC", "degree_Celsius"),
+    ),
+)
 def test_aliases(alias, exp):
     """Test our aliases behave as expected"""
     res = unit_registry.Quantity(1, alias)

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -380,3 +380,25 @@ def test_split_invalid():
         match="Mixture has dimensionality 2 != 1, which is not supported.",
     ):
         unit_registry.split_gas_mixture(1 * unit_registry("CFC400") ** 2)
+
+
+@pytest.mark.parametrize("inp", ("yr",))
+def test_no_autoconversion(inp):
+    """
+    Make sure that the units are not automatically converted to some other value
+
+    The auto-conversion happens if pint thinks that the units are an alias
+    for something else.
+    See {py:func}`test_aliases`.
+    """
+    res = unit_registry.Quantity(1, inp)
+
+    assert str(res.units) == inp
+
+
+@pytest.mark.parametrize("alias, exp", (("degC", "degree_Celsius"),))
+def test_aliases(alias, exp):
+    """Test our aliases behave as expected"""
+    res = unit_registry.Quantity(1, alias)
+
+    assert str(res.units) == exp


### PR DESCRIPTION
Turns out that we had accidentally assigned "yr" to be an alias for "a". This meant we had the following behaviour

```python
>>> from openscm_units import unit_registry
>>> val = unit_registry.Quantity(1, "yr")
>>> val
<Quantity(1, 'a')>
```

This is quite annoying if you need to use string comparisons later (e.g. because you're passing to Fortran).

This PR fixes this so that if you pass in "yr", it stays as yr i.e. you get

```python
>>> from openscm_units import unit_registry
>>> val = unit_registry.Quantity(1, "yr")
>>> val
<Quantity(1, 'yr')>
```