### PR TITLE
fix: Swallow redefinition warnings

### DIFF
--- a/changelog/72.fix.md
+++ b/changelog/72.fix.md
@@ -1,0 +1,2 @@
+Swallow log warnings when added new units.
+These were emitted as warning log messages on every import by default.

--- a/src/openscm_units/_unit_registry.py
+++ b/src/openscm_units/_unit_registry.py
@@ -7,7 +7,7 @@ See also `docs/source/notebooks/design-principles.py`
 from __future__ import annotations
 
 import math
-from typing import Any
+from typing import Any, Literal
 
 import globalwarmingpotentials
 import pandas as pd
@@ -224,18 +224,30 @@ class ScmUnitRegistry(pint.UnitRegistry):
         # below but that also feels like a bad pattern
         super().__init__(*args, **kwargs)
 
-    def add_standards(self) -> None:
+    def add_standards(
+        self, on_redefinition: Literal["ignore", "warn"] = "ignore"
+    ) -> None:
         """
         Add standard units.
 
         Has to be done separately because of pint's weird initialising.
 
-        We suppress redefinition warnings while adding these units
+        Parameters
+        ----------
+        on_redefinition:
+            Action to take on redefinition of existing units
+
+            Some existing units (e.g. kt: kilotonne instead of knot) are redefined here.
+            The default behaviour is to ignore redefinition warnings.
+
+            This overrides the default units registry behaviour for the duration of
+            this method. The previous behaviour is restored afterwards.
+            "raise" is not supported here as the redefinitions are required.
         """
         # Suppress pint's redefinition warnings for units that already exist
         # We temporarily swallow these messages as they are emitted on every import
-        on_redefinition = self._on_redefinition
-        self._on_redefinition = "ignore"
+        previous_on_redefinition = self._on_redefinition
+        self._on_redefinition = on_redefinition
 
         try:
             self._add_gases(_STANDARD_GASES)
@@ -260,7 +272,7 @@ class ScmUnitRegistry(pint.UnitRegistry):
             self._build_cache()
         finally:
             # Restore original redefinition behaviour
-            self._on_redefinition = on_redefinition
+            self._on_redefinition = previous_on_redefinition
 
     def enable_contexts(
         self,

--- a/src/openscm_units/_unit_registry.py
+++ b/src/openscm_units/_unit_registry.py
@@ -229,28 +229,38 @@ class ScmUnitRegistry(pint.UnitRegistry):
         Add standard units.
 
         Has to be done separately because of pint's weird initialising.
+
+        We suppress redefinition warnings while adding these units
         """
-        self._add_gases(_STANDARD_GASES)
+        # Suppress pint's redefinition warnings for units that already exist
+        # We temporarily swallow these messages as they are emitted on every import
+        on_redefinition = self._on_redefinition
+        self._on_redefinition = "ignore"
 
-        self._add_gases({x: x for x in MIXTURES})
+        try:
+            self._add_gases(_STANDARD_GASES)
 
-        self.define("yr = 1 * year")
-        self.define("a = 1 * year = annum")
-        self.define("h = hour")
-        self.define("d = day")
-        self.define("degreeC = degC")
-        self.define("degreeF = degF")
-        self.define("kt = 1000 * t")  # since kt is used for "knot" in the defaults
-        self.define(
-            "Tt = 1000000000000 * t"
-        )  # since Tt is used for "tex" in the defaults
+            self._add_gases({x: x for x in MIXTURES})
 
-        self.define("ppm = [concentrations]")
-        self.define("ppb = ppm / 1000")
-        self.define("ppt = ppb / 1000")
-        # Have to rebuild cache to get right units for ppm as it is defined in
-        # pint
-        self._build_cache()
+            self.define("yr = 1 * year")
+            self.define("a = 1 * year = annum")
+            self.define("h = hour")
+            self.define("d = day")
+            self.define("degreeC = degC")
+            self.define("degreeF = degF")
+            self.define("kt = 1000 * t")  # since kt is used for "knot" in the defaults
+            self.define(
+                "Tt = 1000000000000 * t"
+            )  # since Tt is used for "tex" in the defaults
+
+            self.define("ppm = [concentrations]")
+            self.define("ppb = ppm / 1000")
+            self.define("ppt = ppb / 1000")
+            # Have to rebuild cache to get right units for ppm as it is defined in pint
+            self._build_cache()
+        finally:
+            # Restore original redefinition behaviour
+            self._on_redefinition = on_redefinition
 
     def enable_contexts(
         self,

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -1,10 +1,13 @@
+import logging
 import re
+import warnings
 
 import numpy as np
 import pytest
 from pint.errors import DimensionalityError
 
 from openscm_units import unit_registry
+from openscm_units._unit_registry import ScmUnitRegistry
 from openscm_units.data.mixtures import MIXTURES
 
 
@@ -415,3 +418,24 @@ def test_aliases(alias, exp):
     res = unit_registry.Quantity(1, alias)
 
     assert str(res.units) == exp
+
+
+def test_no_redefinition_warnings(caplog):
+    """
+    Test that creating a unit registry does not produce redefinition warnings.
+
+    When adding standard units via add_standards(), some units like 'yr', 'a',
+    'h', 'd', 'kt', 'Tt', and 'ppm' may already exist in pint's default
+    registry.
+    """
+    with caplog.at_level(logging.DEBUG):
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
+            test_registry = ScmUnitRegistry()
+            test_registry.add_standards()
+
+    # Check for Python warnings
+    assert warning_list == []
+
+    # Check for log messages
+    assert caplog.records == []

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -420,7 +420,8 @@ def test_aliases(alias, exp):
     assert str(res.units) == exp
 
 
-def test_no_redefinition_warnings(caplog):
+@pytest.mark.parametrize("on_redefinition", ["ignore", "warn"])
+def test_redefinition_warnings(caplog, on_redefinition):
     """
     Test that creating a unit registry does not produce redefinition warnings.
 
@@ -432,10 +433,19 @@ def test_no_redefinition_warnings(caplog):
         with warnings.catch_warnings(record=True) as warning_list:
             warnings.simplefilter("always")
             test_registry = ScmUnitRegistry()
-            test_registry.add_standards()
+            test_registry.add_standards(on_redefinition=on_redefinition)
 
-    # Check for Python warnings
-    assert warning_list == []
+    if on_redefinition == "warn":
+        # Check that the warming logs are present
+        assert len(caplog.records)
+        # No Python warnings should be raised
+        assert len(warning_list) == 0
 
-    # Check for log messages
-    assert caplog.records == []
+        assert caplog.records[0].levelno == logging.WARNING
+        assert caplog.records[0].message.startswith("Redefining 'C'")
+    else:
+        # Check for Python warnings
+        assert warning_list == []
+
+        # Check for log messages
+        assert caplog.records == []


### PR DESCRIPTION
## Description

Swallows the redefinition warnings which are emitted on each import if logging is enabled.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
